### PR TITLE
Move hover square draw step before line-to-preview overlay step

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -373,13 +373,13 @@ function drawCanvas() {
         );
     }
 
+    drawHover(data.mouseX, data.mouseY);
+
     if (data.hasOwnProperty("previewedCoords")) {
         const [px, py] = data.previewedCoords;
         drawHover(px, py, screenCoords=false, style="#6C9");
         drawLineToPreview();
     }
-
-    drawHover(data.mouseX, data.mouseY);
 }
 
 // Draws a border around the active image


### PR DESCRIPTION
This small change fixes two issues.

1. It draws the mouse hover below the line, which I personally just think looks better.
![image](https://user-images.githubusercontent.com/11170845/163475308-beb53585-0d4a-45a4-a8f5-460063189574.png)
2. It (somehow) fixes a bug where the previous hover overlay sticks around when you zoom